### PR TITLE
feat: offer csv-formatted totals (by duration) output

### DIFF
--- a/Test.cpp
+++ b/Test.cpp
@@ -1,5 +1,6 @@
 #include "MMeter.h"
 
+#include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
@@ -8,63 +9,63 @@
 
 int calcInt(int ctr)
 {
-	MMETER_FUNC_PROFILER;
+    MMETER_FUNC_PROFILER;
 
-	int val = 0;
-	for (int i = 0; i <= ctr; i++)
-	{
-		val += i;
-	}
-	return val;
+    int val = 0;
+    for (int i = 0; i <= ctr; i++)
+    {
+        val += i;
+    }
+    return val;
 }
 
 int calcFloat(int ctr)
 {
-	MMETER_FUNC_PROFILER;
+    MMETER_FUNC_PROFILER;
 
-	float val = 0;
-	for (int i = 0; i <= ctr; i++)
-	{
-		val += i;
-	}
-	return val;
+    float val = 0;
+    for (int i = 0; i <= ctr; i++)
+    {
+        val += i;
+    }
+    return val;
 }
 
 std::string calcString(int ctr)
 {
-	MMETER_FUNC_PROFILER;
+    MMETER_FUNC_PROFILER;
 
-	std::stringstream ss;
-	for (int i = 0; i <= ctr; i++)
-	{
-		ss << i << ' ';
-	}
-	return ss.str();
+    std::stringstream ss;
+    for (int i = 0; i <= ctr; i++)
+    {
+        ss << i << ' ';
+    }
+    return ss.str();
 }
 
 double calcNumbers(int ctr)
 {
-	MMETER_FUNC_PROFILER;
+    MMETER_FUNC_PROFILER;
 
-	return (calcInt(ctr) + calcFloat(ctr));
+    return (calcInt(ctr) + calcFloat(ctr));
 }
 
 double calcAll(int ctr)
 {
-	MMETER_FUNC_PROFILER;
+    MMETER_FUNC_PROFILER;
 
-	calcString(ctr);
-	return (calcInt(ctr) + calcFloat(ctr));
+    calcString(ctr);
+    return (calcInt(ctr) + calcFloat(ctr));
 }
 
 void test()
 {
-	MMETER_FUNC_PROFILER;
+    MMETER_FUNC_PROFILER;
 
-	int COUNT = 50000000;
+    int COUNT = 50000000;
 
-	calcNumbers(COUNT);
-	calcAll(COUNT);
+    calcNumbers(COUNT);
+    calcAll(COUNT);
 }
 
 int main()
@@ -75,7 +76,16 @@ int main()
     });
     t1.join();
 
+    std::ofstream ofs("test.csv", std::ios::out | std::ios::trunc);
+    if (!ofs)
+    {
+        throw std::ios_base::failure("Failed to open the file for writing.");
+    }
+
     std::cout << std::fixed << std::setprecision(6) << MMeter::getGlobalTreePtr()->totalsByDurationStr() << std::endl;
     std::cout << *MMeter::getGlobalTreePtr() << std::endl;
     MMeter::getGlobalTreePtr()->outputBranchPercentagesToOStream(std::cout);
+    MMeter::getGlobalTreePtr()->outputBranchDurationsToOStream(std::cout);
+    MMeter::getGlobalTreePtr()->outputTotalsCSVToOStream(ofs);
+    MMeter::getGlobalTreePtr()->outputTotalsByDurationCSVToOStream(ofs);
 }

--- a/include/MMeter.h
+++ b/include/MMeter.h
@@ -278,6 +278,18 @@ class FuncProfilerTree
      */
     void outputBranchPercentagesToOStream(std::ostream &out, size_t indent = 0, size_t indentSpaces = 4) const;
 
+    /**
+     * @brief Outputs csv-formatted totals (totalsStr) to a stream
+     * @param out Output stream
+     */
+    void outputTotalsCSVToOStream(std::ostream &out) const;
+
+    /**
+     * @brief Outputs csv-formatted totals (totalsByDurationStr) to a stream
+     * @param out Output stream
+     */
+    void outputTotalsByDurationCSVToOStream(std::ostream &out) const;
+
     /*
     Tree manipulation
     */

--- a/src/MMeter.cpp
+++ b/src/MMeter.cpp
@@ -137,6 +137,17 @@ String FuncProfilerTree::totalsStr(size_t indent, size_t indentSpaces) const
     return ss.str();
 }
 
+void FuncProfilerTree::outputTotalsCSVToOStream(std::ostream &out) const
+{
+    SStream ss;
+    out << "Function Name,Time (s),Call Number\n";
+
+    for (auto [name, result] : totals())
+    {
+        out << name << "," << result.realDuration.count() << "," << result.callCount << std::endl;
+    }
+}
+
 String FuncProfilerTree::totalsByDurationStr(size_t indent, size_t indentSpaces) const
 {
     SStream ss;
@@ -150,6 +161,16 @@ String FuncProfilerTree::totalsByDurationStr(size_t indent, size_t indentSpaces)
     }
 
     return ss.str();
+}
+
+void FuncProfilerTree::outputTotalsByDurationCSVToOStream(std::ostream &out) const
+{
+    out << "Time (s),Call Number,Function Name\n";
+
+    for (auto [duration, result] : totalsByDuration())
+    {
+        out << duration.count() << "," << result.callCount << "," << result.branchName << std::endl;
+    }
 }
 
 void FuncProfilerTree::outputBranchDurationsToOStream(std::ostream &out, size_t indent, size_t indentSpaces) const
@@ -175,7 +196,8 @@ void FuncProfilerTree::outputBranchDurationsToOStream(std::ostream &out, size_t 
             out << durationPtrPair.first.count() << "s /#";
             if (durationPtrPair.second == nullptr)
             {
-                out << mCount << " - " << "<body>" << std::endl;
+                out << mCount << " - "
+                    << "<body>" << std::endl;
             }
             else
             {


### PR DESCRIPTION
This commit adds the ability to output csv-formatted Totals/TotalsByDuration information to an std::ostream.

I would find very useful for comparing multiple runs against each other, in the process of e.g. refactoring.

Let me know what you think, thanks.

BTW: I think this is unused 

https://github.com/LMauricius/MMeter/blob/42df645729034ad13482b80656cc0211df94986d/src/MMeter.cpp#L261